### PR TITLE
Replaced dls-controls with DiamondLightSource

### DIFF
--- a/.gitremotes
+++ b/.gitremotes
@@ -1,2 +1,2 @@
-dls-controls git@github.com:dls-controls/pmacUtil.git
+DiamondLightSource git@github.com:DiamondLightSource/pmacUtil.git
 


### PR DESCRIPTION
Repository was automatically transferred from `dls-controls/pmacUtil` using https://gitlab.diamond.ac.uk/github/github-scripts